### PR TITLE
Add poetry script as a replacement for console_scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ pylint = "^2.8.2"
 pytest = ">=4.6.6"
 rope = "0.19.0"
 
+[tool.poetry.scripts]
+rfd = "rfd.__main__:cli"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
###### Motivation for this change

After switching to poetry, the console script `rfd` was removed meaning the `rfd` command did not work.

This fixes the issue by using [poetry scripts](https://python-poetry.org/docs/pyproject/#scripts).